### PR TITLE
Disable Unirest socket timeout

### DIFF
--- a/src/main/java/org/polypheny/simpleclient/scenario/multimedia/MultimediaBench.java
+++ b/src/main/java/org/polypheny/simpleclient/scenario/multimedia/MultimediaBench.java
@@ -39,6 +39,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Vector;
 import java.util.concurrent.ConcurrentHashMap;
+import kong.unirest.Unirest;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -69,6 +70,10 @@ public class MultimediaBench extends Scenario {
     private final Map<Integer, String> queryTypes;
     private final Map<Integer, List<Long>> measuredTimePerQueryType;
 
+    static {
+        Unirest.config().reset();
+        Unirest.config().socketTimeout( 0 );
+    }
 
     public MultimediaBench( Executor.ExecutorFactory executorFactory, MultimediaConfig config, boolean commitAfterEveryQuery, boolean dumpQueryList ) {
         //never dump mm queries, because the dumps can get very large for large binary inserts


### PR DESCRIPTION
Disable the socket timeout for multimedia requests that take a large amount of time.