### PR TITLE
Add missing handling for MongoQL benchmarks

### DIFF
--- a/src/main/java/org/polypheny/simpleclient/main/ChronosAgent.java
+++ b/src/main/java/org/polypheny/simpleclient/main/ChronosAgent.java
@@ -234,6 +234,7 @@ public class ChronosAgent extends AbstractChronosAgent {
         switch ( config.system ) {
             case "polypheny":
             case "polypheny-rest":
+            case "polypheny-mongoql":
                 databaseInstance = new PolyphenyDbInstance( polyphenyControlConnector, executorFactory, outputDirectory, config );
                 scenario.createSchema( true );
                 break;


### PR DESCRIPTION
This hotfix-PR adds a missing parameter, which is needed to correctly evaluate with polypheny-mongoql.