### PR TITLE
Adds Missing PolyphenyInstance call for Docker Endpoint

### DIFF
--- a/src/main/java/org/polypheny/simpleclient/executor/PolyphenyDbExecutor.java
+++ b/src/main/java/org/polypheny/simpleclient/executor/PolyphenyDbExecutor.java
@@ -273,7 +273,7 @@ public interface PolyphenyDbExecutor extends Executor {
 
 
     default int getDockerInstanceId() {
-        String url = "http://localhost:" + PolyphenyVersionSwitch.getInstance().uiPort + "/getDockerInstances";
+        String url = "http://localhost:" + PolyphenyVersionSwitch.getInstance().uiPort + PolyphenyVersionSwitch.getInstance().dockerInstancesEndpoint;
         HttpResponse<String> response = Unirest.get( url ).asString();
 
         if ( response.getStatus() == 200 ) {


### PR DESCRIPTION
This switch is already done for `checkIfDockerIsReady`, but was missed for `dockerInstanceId`.