### PR TITLE
Add --job option to benchmark a single job

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,7 @@ dependencies {
     implementation group: 'org.polypheny', name: 'control-connector', version: '2.2.1'  // License: Apache 2.0
 
     // Chronos
-    implementation group: 'org.chronos-eaas', name: 'chronos-agent', version: '2.4.3' // License: MIT
+    implementation group: 'org.chronos-eaas', name: 'chronos-agent', version: '2.5.0' // License: MIT
 
     // REST
     implementation group: 'com.konghq', name: 'unirest-java', version: '3.14.5' // License: MIT

--- a/src/main/java/org/polypheny/simpleclient/cli/ChronosCommand.java
+++ b/src/main/java/org/polypheny/simpleclient/cli/ChronosCommand.java
@@ -70,6 +70,9 @@ public class ChronosCommand implements CliRunnable {
     @Option(name = { "--queryList" }, arity = 0, description = "Dump all queries into a file (default: false).")
     public boolean dumpQueryList = false;
 
+    @Option(name = { "--job" }, title = "Id of the job to run", description = "Run a single chronos job (default: null)")
+    public Integer jobId = null;
+
 
     @Override
     public int run() {
@@ -83,7 +86,23 @@ public class ChronosCommand implements CliRunnable {
 
         AbstractChronosAgent aca = new ChronosAgent( address, port, true, true, environment, supports.split( "," ), writeCsv, dumpQueryList );
         aca.setDaemon( false );
+        if ( jobId != null ) {
+            aca.setSingleJobId( jobId );
+        }
         aca.start();
+        while ( true ) {
+            try {
+                aca.join();
+                break;
+            } catch ( InterruptedException e ) {
+                // ignore
+            }
+        }
+
+        if (jobId != null) {
+            // Make sure simple-client exits when the job is done
+            System.exit( 0 );
+        }
 
         return 0;
     }

--- a/src/main/java/org/polypheny/simpleclient/main/ChronosAgent.java
+++ b/src/main/java/org/polypheny/simpleclient/main/ChronosAgent.java
@@ -570,7 +570,15 @@ public class ChronosAgent extends AbstractChronosAgent {
 
     @Override
     protected void aborted( ChronosJob chronosJob ) {
-
+        if ( getSingleJobId() != null ) {
+            try {
+                if ( polyphenyControlConnector != null ) {
+                    polyphenyControlConnector.stopPolypheny();
+                }
+            } finally {
+                System.exit( 1 );
+            }
+        }
     }
 
 


### PR DESCRIPTION
This uses the [new feature](https://github.com/Chronos-EaaS/Chronos-Agent/pull/7) of the Chronos Agent.  With this it is possible to run a single benchmark identified by its `jobid`.

Builds fail because it needs a new release of the Chronos Agent.