### PR TITLE
Improve data collection

### DIFF
--- a/src/main/java/org/polypheny/simpleclient/executor/PolyphenyDbExecutor.java
+++ b/src/main/java/org/polypheny/simpleclient/executor/PolyphenyDbExecutor.java
@@ -38,6 +38,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import kong.unirest.core.HttpResponse;
 import kong.unirest.core.Unirest;
+import kong.unirest.core.UnirestInstance;
 import kong.unirest.core.json.JSONArray;
 import kong.unirest.core.json.JSONObject;
 import lombok.Getter;
@@ -720,34 +721,37 @@ public interface PolyphenyDbExecutor extends Executor {
         private final List<PolyphenyStatus> statuses = new ArrayList<>();
 
         private final String url;
+        private final UnirestInstance unirest;
 
 
         private StatusGatherer() {
             url = "http://" + ChronosCommand.hostname + ":" + PolyphenyVersionSwitch.getInstance().uiPort + "/status/";
+            unirest = Unirest.spawnInstance();
+            unirest.config().requestTimeout( 30000 );
         }
 
 
         public PolyphenyStatus gatherOnce() {
             return new PolyphenyStatus(
-                    Long.parseLong( Unirest.get( url + "memory-current" ).asString().getBody() ),
-                    Integer.parseInt( Unirest.get( url + "transactions-active" ).asString().getBody() ),
-                    Integer.parseInt( Unirest.get( url + "monitoring-queue" ).asString().getBody() )
+                    Long.parseLong( unirest.get( url + "memory-current" ).asString().getBody() ),
+                    Integer.parseInt( unirest.get( url + "transactions-active" ).asString().getBody() ),
+                    Integer.parseInt( unirest.get( url + "monitoring-queue" ).asString().getBody() )
             );
         }
 
 
         public PolyphenyFullStatus gatherFullOnce() {
             return new PolyphenyFullStatus(
-                    Unirest.get( url + "uuid" ).asString().getBody(),
-                    Unirest.get( url + "version" ).asString().getBody(),
-                    Unirest.get( url + "hash" ).asString().getBody(),
-                    Long.parseLong( Unirest.get( url + "memory-current" ).asString().getBody() ),
-                    Integer.parseInt( Unirest.get( url + "transactions-since-restart" ).asString().getBody() ),
-                    Integer.parseInt( Unirest.get( url + "transactions-active" ).asString().getBody() ),
-                    Integer.parseInt( Unirest.get( url + "cache-implementation" ).asString().getBody() ),
-                    Integer.parseInt( Unirest.get( url + "cache-queryplan" ).asString().getBody() ),
-                    Integer.parseInt( Unirest.get( url + "cache-routingplan" ).asString().getBody() ),
-                    Integer.parseInt( Unirest.get( url + "monitoring-queue" ).asString().getBody() )
+                    unirest.get( url + "uuid" ).asString().getBody(),
+                    unirest.get( url + "version" ).asString().getBody(),
+                    unirest.get( url + "hash" ).asString().getBody(),
+                    Long.parseLong( unirest.get( url + "memory-current" ).asString().getBody() ),
+                    Integer.parseInt( unirest.get( url + "transactions-since-restart" ).asString().getBody() ),
+                    Integer.parseInt( unirest.get( url + "transactions-active" ).asString().getBody() ),
+                    Integer.parseInt( unirest.get( url + "cache-implementation" ).asString().getBody() ),
+                    Integer.parseInt( unirest.get( url + "cache-queryplan" ).asString().getBody() ),
+                    Integer.parseInt( unirest.get( url + "cache-routingplan" ).asString().getBody() ),
+                    Integer.parseInt( unirest.get( url + "monitoring-queue" ).asString().getBody() )
             );
         }
 

--- a/src/main/java/org/polypheny/simpleclient/main/ChronosAgent.java
+++ b/src/main/java/org/polypheny/simpleclient/main/ChronosAgent.java
@@ -441,6 +441,11 @@ public class ChronosAgent extends AbstractChronosAgent {
                 if ( config.router != null && config.router.equals( "icarus" ) && PolyphenyVersionSwitch.getInstance().hasIcarusRoutingSettings ) {
                     polyphenyDbInstance.setIcarusRoutingTraining( false );
                 }
+                PolyphenyFullStatus status = polyphenyDbInstance.getStatusGatherer().gatherFullOnce();
+                properties.put( "pdbStatus_implementationCacheSize_after_warmup", status.implementationCacheSize() );
+                properties.put( "pdbStatus_queryPlanCacheSize_after_warmup", status.queryPlanCacheSize() );
+                properties.put( "pdbStatus_routingPlanCacheSize_after_warmup", status.routingPlanCacheSize() );
+                properties.put( "pdbStatus_monitoringQueueSize_after_warmup", status.monitoringQueueSize() );
             }
         } catch ( Exception e ) {
             databaseInstance.tearDown();

--- a/src/main/java/org/polypheny/simpleclient/scenario/EvaluationThread.java
+++ b/src/main/java/org/polypheny/simpleclient/scenario/EvaluationThread.java
@@ -96,7 +96,9 @@ public class EvaluationThread extends Thread {
             measuredTimes.add( measuredTime );
             measuredTimePerQueryType.get( queryListEntry.templateId ).add( measuredTime );
             for ( Integer id : queryListEntry.templateIds ) {
-                measuredTimePerQueryType.get( id ).add( measuredTime );
+                if ( id != queryListEntry.templateId ) {
+                    measuredTimePerQueryType.get( id ).add( measuredTime );
+                }
             }
             if ( commitAfterEveryQuery ) {
                 try {


### PR DESCRIPTION
 - Do not record the same execution time twice for the same query
 - Add a 30 second timeout to HTTP requests by the StatusGatherer.  Sometimes the internal webserver in Polypheny crashes without cleaning up the listening socket, this would cause the status gatherer code to hang indefinitely
 - Collect various cache sizes after the warmup phase