### PR TITLE
Small improvements

### DIFF
--- a/src/main/java/org/polypheny/simpleclient/main/ChronosAgent.java
+++ b/src/main/java/org/polypheny/simpleclient/main/ChronosAgent.java
@@ -178,6 +178,10 @@ public class ChronosAgent extends AbstractChronosAgent {
         // Parse CDL
         Map<String, String> parsedConfig = parseConfig( chronosJob );
 
+        if ( !parsedConfig.containsKey( "queryMode" ) ) {
+            throw new RuntimeException( "Query mode not specified" );
+        }
+
         switch ( parsedConfig.get( "queryMode" ) ) {
             case "Table":
                 queryMode = QueryMode.TABLE;

--- a/src/main/java/org/polypheny/simpleclient/main/ProgressReporter.java
+++ b/src/main/java/org/polypheny/simpleclient/main/ProgressReporter.java
@@ -26,6 +26,7 @@ package org.polypheny.simpleclient.main;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Queue;
 import java.util.concurrent.atomic.AtomicLong;
 import lombok.extern.slf4j.Slf4j;
 import org.polypheny.simpleclient.query.QueryListEntry;
@@ -70,12 +71,12 @@ public abstract class ProgressReporter {
 
         private final int totalNumber;
         private final ProgressReporter theProgressReporter;
-        private final List<QueryListEntry> theList;
+        private final Queue<QueryListEntry> theQueue;
 
 
-        public ReportQueryListProgress( List<QueryListEntry> list, ProgressReporter progressReporter ) {
+        public ReportQueryListProgress( Queue<QueryListEntry> list, ProgressReporter progressReporter ) {
             this.totalNumber = list.size();
-            this.theList = list;
+            this.theQueue = list;
             this.theProgressReporter = progressReporter;
         }
 
@@ -83,8 +84,8 @@ public abstract class ProgressReporter {
         @Override
         public void run() {
             while ( true ) {
-                theProgressReporter.update( totalNumber - theList.size(), totalNumber );
-                if ( theList.isEmpty() ) {
+                theProgressReporter.update( totalNumber - theQueue.size(), totalNumber );
+                if ( theQueue.isEmpty() ) {
                     break;
                 }
                 try {
@@ -97,7 +98,7 @@ public abstract class ProgressReporter {
 
 
         public void updateProgress() {
-            theProgressReporter.update( totalNumber - theList.size(), totalNumber );
+            theProgressReporter.update( totalNumber - theQueue.size(), totalNumber );
         }
 
     }

--- a/src/main/java/org/polypheny/simpleclient/scenario/PolyphenyScenario.java
+++ b/src/main/java/org/polypheny/simpleclient/scenario/PolyphenyScenario.java
@@ -34,8 +34,10 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Queue;
 import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import lombok.extern.slf4j.Slf4j;
@@ -61,11 +63,13 @@ public abstract class PolyphenyScenario extends Scenario {
     }
 
 
-    protected long commonExecute( List<QueryListEntry> queryList, ProgressReporter progressReporter, File outputDirectory, int numberOfThreads, Function<Query, String> toString, Supplier<Executor> executor, Random random ) {
-        Collections.shuffle( queryList, random );
+    protected long commonExecute( List<QueryListEntry> queries, ProgressReporter progressReporter, File outputDirectory, int numberOfThreads, Function<Query, String> toString, Supplier<Executor> executor, Random random ) {
+        Collections.shuffle( queries, random );
 
         // This dumps the queries independent of the selected interface
-        dumpQueryList( outputDirectory, queryList, toString );
+        dumpQueryList( outputDirectory, queries, toString );
+
+        Queue<QueryListEntry> queryList = new ConcurrentLinkedQueue<>( queries );
 
         log.info( "Executing benchmark..." );
         (new Thread( new ProgressReporter.ReportQueryListProgress( queryList, progressReporter ) )).start();

--- a/src/main/java/org/polypheny/simpleclient/scenario/Scenario.java
+++ b/src/main/java/org/polypheny/simpleclient/scenario/Scenario.java
@@ -26,8 +26,6 @@ package org.polypheny.simpleclient.scenario;
 
 import com.google.common.base.Joiner;
 import java.io.File;
-import java.text.DecimalFormat;
-import java.text.ParseException;
 import java.util.List;
 import java.util.LongSummaryStatistics;
 import java.util.Map;
@@ -101,17 +99,9 @@ public abstract class Scenario {
 
 
     protected double calculateMean( List<Long> times ) {
-        DecimalFormat df = new DecimalFormat( "0.000" );
         OptionalDouble meanOptional = times.stream().mapToLong( Long::longValue ).average();
         if ( meanOptional.isPresent() ) {
-            // scale
-            double mean = meanOptional.getAsDouble() / 1000000.0;
-            String roundFormat = df.format( mean );
-            try {
-                return df.parse( roundFormat ).doubleValue();
-            } catch ( ParseException e ) {
-                log.error( "Exception", e );
-            }
+            return Math.round( meanOptional.getAsDouble() / 1_000 ) / 1_000.0;
         }
         return -1;
     }
@@ -125,15 +115,7 @@ public abstract class Scenario {
 
 
     protected double processDoubleValue( double value ) {
-        DecimalFormat df = new DecimalFormat( "0.000" );
-        double temp1 = value / 1_000_000;
-        String roundFormat = df.format( temp1 );
-        try {
-            return df.parse( roundFormat ).doubleValue();
-        } catch ( ParseException e ) {
-            log.error( "Exception", e );
-        }
-        return -1;
+        return Math.round( value / 1_000 ) / 1_000.0;
     }
 
 

--- a/src/main/java/org/polypheny/simpleclient/scenario/coms/Coms.java
+++ b/src/main/java/org/polypheny/simpleclient/scenario/coms/Coms.java
@@ -35,6 +35,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
@@ -276,7 +277,7 @@ public class Coms extends PolyphenyScenario {
 
         ArrayList<EvaluationThread> threads = new ArrayList<>();
         for ( List<QueryListEntry> queryList : organized ) {
-            threads.add( new EvaluationThread( queryList, executorFactory.createExecutorInstance( csvWriter, NAMESPACE ), queryTypes.keySet(), commitAfterEveryQuery ) );
+            threads.add( new EvaluationThread( new ConcurrentLinkedQueue<>( queryList ), executorFactory.createExecutorInstance( csvWriter, NAMESPACE ), queryTypes.keySet(), commitAfterEveryQuery ) );
         }
 
         EvaluationThreadMonitor threadMonitor = new EvaluationThreadMonitor( threads );


### PR DESCRIPTION
 - Prevent a `NullPointerException` if `queryMode` is missing
 - Round doubles directly without formatting and then parsing a string
 - Use a `Queue` instead of a `List` to share queries between threads